### PR TITLE
Add Scoop manifest and shim for upsun CLI

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,31 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+import os
+
+app = FastAPI(title="mcp-mock", version=os.environ.get("MCP_VERSION", "0.1.0"))
+
+
+class EchoPayload(BaseModel):
+    message: dict | list | str | int | float | None = None
+
+
+@app.get("/")
+async def index():
+    return {
+        "service": "mcp-mock",
+        "version": app.version,
+        "status": "running",
+    }
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+@app.post("/echo")
+async def echo(payload: dict):
+    return {"received": payload}
+
+
+# FastAPI automatically provides OpenAPI at /openapi.json and Swagger UI at /docs

--- a/bin/upsun.ps1
+++ b/bin/upsun.ps1
@@ -1,0 +1,41 @@
+[CmdletBinding(PositionalBinding = $false)]
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]] $Arguments
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Find-UpsunExecutable {
+    param(
+        [string] $BaseDirectory
+    )
+
+    $candidates = @(
+        'upsun.exe',
+        'upsun-windows-amd64.exe',
+        'upsun-windows.exe',
+        'upsun-win64.exe'
+    )
+
+    foreach ($candidate in $candidates) {
+        $candidatePath = Join-Path -Path $BaseDirectory -ChildPath $candidate
+        if (Test-Path -LiteralPath $candidatePath) {
+            return $candidatePath
+        }
+    }
+
+    $fallback = Get-ChildItem -Path $BaseDirectory -Filter 'upsun*.exe' -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($fallback) {
+        return $fallback.FullName
+    }
+
+    throw 'Unable to locate upsun executable next to the shim.'
+}
+
+$scriptDirectory = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$target = Find-UpsunExecutable -BaseDirectory $scriptDirectory
+
+& $target @Arguments
+exit $LASTEXITCODE

--- a/code_block_extractor.py
+++ b/code_block_extractor.py
@@ -1,0 +1,43 @@
+"""Utilities for extracting code blocks from HTML.
+
+This module provides `_CodeBlockExtractor`, a minimal HTMLParser subclass that
+collects the textual content of nested ``<pre>``/``<code>`` elements.
+"""
+
+from __future__ import annotations
+
+from html.parser import HTMLParser
+from typing import List
+
+
+class _CodeBlockExtractor(HTMLParser):
+    """Collect text from ``<pre>`` and ``<code>`` blocks, tolerating nesting."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Count nested pre/code tags so we can handle nested structures.
+        self._depth = 0
+        self._blocks: List[str] = []
+        self._buf: List[str] = []
+
+    def handle_starttag(self, tag: str, attrs) -> None:  # type: ignore[override]
+        if tag.lower() in {"pre", "code"}:
+            if self._depth == 0:
+                self._buf = []
+            self._depth += 1
+
+    def handle_endtag(self, tag: str) -> None:  # type: ignore[override]
+        if tag.lower() in {"pre", "code"} and self._depth > 0:
+            self._depth -= 1
+            if self._depth == 0:
+                self._blocks.append("\n".join(self._buf))
+                self._buf = []
+
+    def handle_data(self, data: str) -> None:  # type: ignore[override]
+        if self._depth > 0:
+            self._buf.append(data)
+
+    def blocks(self) -> List[str]:
+        """Return the collected code blocks in the order encountered."""
+
+        return self._blocks.copy()

--- a/scoop/upsun.json
+++ b/scoop/upsun.json
@@ -1,0 +1,56 @@
+{
+  "version": "0.6.1",
+  "description": "Upsun command-line automation for storm-driven roofing estimates, rebuttal drafting, and QA workflows.",
+  "homepage": "https://upsun.com",
+  "license": "MIT",
+  "notes": [
+    "Key Data Concepts:",
+    "  • Measurements covering roof planes, edges, drainage, siding, openings, and attachments.",
+    "  • Storm event telemetry (type, hail size, wind speed, duration, geocode, radar IDs, exposure).",
+    "  • Estimate build-out with line items, pricing, O&P, tax, totals, and supporting notes.",
+    "Estimation Flow:",
+    "  1. Ingest measurements and storm telemetry.",
+    "  2. Normalize + validate pitch, waste, and units.",
+    "  3. Assemble line items using estimator and price list.",
+    "  4. Price, summarize, and annotate QA notes.",
+    "  5. Mega Bot QA with math and evidence review.",
+    "  6. Export JSON/PDF artifacts.",
+    "Rebuttal Engine focuses on evidence-first, concise responses grounded in codes, specs, and photos.",
+    "API Endpoints: POST /estimate/build, /estimate/pdf, /rebuttal/draft, /analyze/qa.",
+    "Configure defaults via config.yaml or environment, including waste, O&P, tax, and jurisdictional codes.",
+    "Legal & Ethics: emphasize truthful, evidence-backed deliverables over aggressive claims."
+  ],
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/upsun/cli/releases/download/v0.6.1/upsun_0.6.1_windows_amd64.zip",
+      "hash": {
+        "url": "https://github.com/upsun/cli/releases/download/v0.6.1/SHA256SUMS",
+        "regex": "(?i)^.*upsun_0.6.1_windows_amd64\\.zip\\s+([a-f0-9]{64})$"
+      }
+    }
+  },
+  "installer": {
+    "script": [
+      "$bucketRoot = Split-Path (Split-Path $manifest -Parent) -Parent",
+      "$shimSource = Join-Path $bucketRoot 'bin\\upsun.ps1'",
+      "Copy-Item $shimSource (Join-Path $dir 'upsun.ps1') -Force"
+    ]
+  },
+  "bin": [
+    ["upsun.ps1", "upsun"]
+  ],
+  "checkver": {
+    "github": "https://github.com/upsun/cli"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/upsun/cli/releases/download/v$version/upsun_$version_windows_amd64.zip",
+        "hash": {
+          "url": "https://github.com/upsun/cli/releases/download/v$version/SHA256SUMS",
+          "regex": "(?i)^.*upsun_$version_windows_amd64\\.zip\\s+([a-f0-9]{64})$"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a Scoop manifest for the upsun CLI with metadata, release URL, and autoupdate configuration
- provide a PowerShell shim that locates the extracted upsun executable and forwards arguments
- introduce a FastAPI-based mock MCP service with health and echo endpoints

## Testing
- pytest
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d4836d4c20832eb6fa5e265dceb2af