### PR TITLE
docs: add token test script and fix ci secret handling

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -6,11 +6,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  # Customize these via repository secrets or workflow inputs
-  ACR_NAME: ${{ secrets.ACR_NAME }}
-  RESOURCE_GROUP: ${{ secrets.RESOURCE_GROUP }}
-  CONTAINERAPPS_ENV: ${{ secrets.CONTAINERAPPS_ENV }}
-  CONTAINERAPP_NAME: ${{ secrets.CONTAINERAPP_NAME }}
+  # Static workflow defaults
   IMAGE_REPO: mcp-mock
 
 jobs:
@@ -20,23 +16,35 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: 'Prepare environment from secrets'
+        # Exports repository secrets into environment variables for subsequent steps
+        run: |
+          echo "ACR_NAME=${{ secrets.ACR_NAME }}" >> $GITHUB_ENV
+          echo "RESOURCE_GROUP=${{ secrets.RESOURCE_GROUP }}" >> $GITHUB_ENV
+          echo "CONTAINERAPPS_ENV=${{ secrets.CONTAINERAPPS_ENV }}" >> $GITHUB_ENV
+          echo "CONTAINERAPP_NAME=${{ secrets.CONTAINERAPP_NAME }}" >> $GITHUB_ENV
+          echo "AZURE_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }}" >> $GITHUB_ENV
+          echo "AZURE_TENANT_ID=${{ secrets.AZURE_TENANT_ID }}" >> $GITHUB_ENV
+          echo "AZURE_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION_ID }}" >> $GITHUB_ENV
+          echo "AZURE_CREDENTIALS=${{ secrets.AZURE_CREDENTIALS }}" >> $GITHUB_ENV
+
       - name: 'Login to Azure (Service Principal if available)'
         # Ensure the secret is present and non-empty before using SPN login
-        if: ${{ secrets.AZURE_CREDENTIALS != '' }}
+        if: ${{ env.AZURE_CREDENTIALS != '' }}
         uses: azure/login@v1
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          creds: ${{ env.AZURE_CREDENTIALS }}
 
       - name: 'Login to Azure via OIDC (workload identity federation)'
         # Use OIDC when no SPN credentials secret has been set
-        if: ${{ secrets.AZURE_CREDENTIALS == '' }}
+        if: ${{ env.AZURE_CREDENTIALS == '' }}
         uses: azure/login@v1
         with:
           # For OIDC, store only the client-id/tenant-id/subscription-id in secrets.
           # The action exchanges a GitHub OIDC token for an Azure AD access token using the federated credential.
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
 
       - name: Configure ACR and get login server
         id: acr-info

--- a/scripts/check_actions_token.sh
+++ b/scripts/check_actions_token.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# check_actions_token.sh
+# Safely test a fine-grained GitHub token for permission to read repository Actions variables.
+# Usage: ./scripts/check_actions_token.sh
+# You'll be prompted to paste the token (it will not be echoed).
+
+set -euo pipefail
+
+REPO_OWNER=${REPO_OWNER:-Skeries}
+REPO_NAME=${REPO_NAME:-Skeries}
+API="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/actions/variables?per_page=1"
+
+read -s -p "Paste fine-grained token (will not be shown): " TOKEN
+echo
+
+TMPRESP=$(mktemp)
+HTTP_CODE=$(curl -sS -o "$TMPRESP" -w "%{http_code}" \
+  -H "Authorization: token $TOKEN" \
+  -H "Accept: application/vnd.github.v3+json" \
+  "$API")
+BODY=$(cat "$TMPRESP")
+rm -f "$TMPRESP"
+
+if [[ "$HTTP_CODE" == "200" ]]; then
+  echo "OK: token can read repository Actions variables (HTTP 200)."
+  echo "$BODY" | jq .
+  exit 0
+fi
+
+if [[ "$HTTP_CODE" == "403" ]]; then
+  echo "403: token is not authorized to read repository Actions variables." >&2
+  echo " - Check that the token is a fine-grained token scoped to the repository ${REPO_OWNER}/${REPO_NAME}." >&2
+  echo " - Ensure the token's Actions permission allows reading repository variables/secrets." >&2
+  echo " - If your organization enforces SSO, authorize the token for the organization." >&2
+  echo "Response body:" >&2
+  echo "$BODY" | jq . >&2 || echo "$BODY" >&2
+  exit 2
+fi
+
+# Other responses
+echo "$HTTP_CODE: unexpected response" >&2
+echo "$BODY" | jq . || echo "$BODY" >&2
+exit 3


### PR DESCRIPTION
Adds scripts/check_actions_token.sh and updates CI workflow to export secrets into GITHUB_ENV and use env checks for azure/login. Prevents top-level secret interpolation in workflow env and fixes editor/linter warnings.